### PR TITLE
chore: replace authorization header with x-api-key

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add to your Cursor MCP settings (`~/.cursor/mcp.json` or workspace `.cursor/mcp.
     "tusk-drift": {
       "url": "https://api.usetusk.ai/api/drift-mcp",
       "headers": {
-        "Authorization": "Bearer YOUR_TUSK_API_KEY"
+        "x-api-key": "YOUR_TUSK_API_KEY"
       }
     }
   }
@@ -38,7 +38,7 @@ Add to your Cursor MCP settings (`~/.cursor/mcp.json` or workspace `.cursor/mcp.
       "command": "npx",
       "args": ["-y", "mcp-remote", "https://api.usetusk.ai/api/drift-mcp"],
       "env": {
-        "MCP_HEADERS": "{\"Authorization\": \"Bearer YOUR_TUSK_API_KEY\"}"
+        "MCP_HEADERS": "{\"x-api-key\": \"YOUR_TUSK_API_KEY\"}"
       }
     }
   }

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -64,7 +64,7 @@ export class TuskDriftApiClient implements DriftDataProvider {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${this.apiToken}`,
+        "x-api-key": this.apiToken,
       },
       body: JSON.stringify(body),
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 export interface TuskDriftConfig {
   /** Base URL for the Tusk Drift API (e.g., https://api.usetusk.ai) */
   apiBaseUrl: string;
-  /** API key or JWT token for authentication */
+  /** API key for authentication (sent via x-api-key header) */
   apiToken: string;
   /** Optional default observable service ID (can be overridden per request) */
   observableServiceId?: string;


### PR DESCRIPTION
- [ ] should be merged when tusk backend PR is deployed